### PR TITLE
[fix] Address 엔티티의 컬럼명 매핑 오류 수정

### DIFF
--- a/src/main/java/org/ktb/matajo/entity/Address.java
+++ b/src/main/java/org/ktb/matajo/entity/Address.java
@@ -51,13 +51,13 @@ public class Address extends BaseEntity {
     @Column(length = 100)
     private String bname1;  // 법정리의 읍/면 이름 ("동"지역일 경우에는 공백, "리"지역일 경우에는 "읍" 또는 "면" 정보가 들어갑니다.)
 
-    @Column(length = 100)
+    @Column(name = "bname1_english", length = 100)
     private String bname1English;  // 법정리의 읍/면 이름의 영문 ("동"지역일 경우에는 공백, "리"지역일 경우에는 "읍" 또는 "면" 정보가 들어갑니다.)
 
     @Column(length = 100)
     private String bname2;  // 법정동/법정리 이름
 
-    @Column(length = 100)
+    @Column(name = "bname2_english", length = 100)
     private String bname2English;  // 법정동/법정리 이름의 영문
 
     @Column(length = 50)


### PR DESCRIPTION
### Description
Address 엔티티에서 bname2English 필드와 데이터베이스 컬럼명(bname2_english) 간의 
매핑 오류를 수정하였습니다. @Column 어노테이션을 추가하여 JPA 네이밍 전략과 
실제 데이터베이스 컬럼명을 일치시켰습니다.

<!--
  간단하게 PR의 목적을 설명하세요.
  이 PR이 해결하려는 문제나 추가하려는 기능에 대해 요약해주세요.
-->

### Related Issues

<!--
  관련된 이슈 번호를 참고하세요.
  예: Fixes #123, Closes #456
-->
- Resolves #[이슈 번호]

### Changes Made

<!--
  이 PR에서 변경된 사항을 설명하세요.
  코드, 문서, 설정 등 변경된 내용을 상세히 기술합니다.
-->

1. [변경 내용 1]
2. [변경 내용 2]
3. [변경 내용 3]

### Screenshots or Video

<!--
  변경된 사항이 UI에 영향을 미치는 경우, 변경 전후의 스크린샷이나 동영상을 첨부하세요.
-->

### Testing

<!--
  변경 사항을 테스트한 방법을 설명하세요.
  테스트한 환경 (OS, 브라우저, 장치 등)과 테스트 절차를 구체적으로 기술합니다.
-->

1. [테스트 1]
2. [테스트 2]
3. [테스트 3]

### Checklist

<!--
  PR 작성 시 다음 항목들을 확인하세요.
-->

- [ ] 코드가 정상적으로 컴파일되는지 확인했습니다.
- [ ] 모든 테스트가 성공적으로 통과했습니다.
- [ ] 관련 문서를 업데이트했습니다.
- [ ] PR이 관련 이슈를 정확히 참조하고 있습니다.
- [ ] 코드 스타일 가이드라인을 준수했습니다.
- [ ] 코드 리뷰어를 지정했습니다.

### Additional Notes

<!--
  리뷰어가 이해하는 데 도움이 될 추가적인 참고 사항이나 정보가 있다면 여기에 작성하세요.
-->

