### PR TITLE
[REFACTOR] 구 이름 검색 메서드 이름 변경

### DIFF
--- a/src/main/java/org/ktb/matajo/repository/LocationInfoRepository.java
+++ b/src/main/java/org/ktb/matajo/repository/LocationInfoRepository.java
@@ -11,6 +11,6 @@ public interface LocationInfoRepository extends JpaRepository<LocationInfo, Long
     Optional<LocationInfo> findByOriginalName(String originalName);
 
     // 구 이름으로 검색 (가장 첫번째에 있는 구)
-    Optional<LocationInfo> findByCityDistrictContaining(String cityDistrict);
+    Optional<LocationInfo> findFirstByCityDistrictContaining(String cityDistrict);
 
 }

--- a/src/main/java/org/ktb/matajo/service/location/LocationInfoService.java
+++ b/src/main/java/org/ktb/matajo/service/location/LocationInfoService.java
@@ -46,7 +46,7 @@ public class LocationInfoService {
         
         // 2. 구 이름 기반 검색
         if (guName != null && !guName.isBlank()) {
-            Optional<LocationInfo> guMatch = locationInfoRepository.findByCityDistrictContaining(guName);
+            Optional<LocationInfo> guMatch = locationInfoRepository.findFirstByCityDistrictContaining(guName);
             if (guMatch.isPresent()) {
                 log.debug("구 이름 매칭 결과 발견: {}", guName);
                 return Collections.singletonList(guMatch.get());


### PR DESCRIPTION
### Description

구 검색 시 단일 쿼리 출력으로 변경

### Related Issues

#50 

### Changes Made
- LocationInfoRepository에서 구 이름으로 검색하는 메서드의 이름을 findByCityDistrictContaining에서 findFirstByCityDistrictContaining으로 변경하여, 첫 번째 매칭 결과를 반환하도록 개선.
- LocationInfoService에서 해당 메서드를 호출하는 부분도 업데이트하여 일관성을 유지.

