### PR TITLE
[FEAT] XSS 방어를 위한 문자열 이스케이프 및 CORS 설정 강화

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -50,6 +50,9 @@ dependencies {
     implementation 'com.bucket4j:bucket4j-core:8.10.1'
     implementation 'com.bucket4j:bucket4j-redis:8.10.1'
 
+    // 문자열 이스케이프 및 언이스케이프
+    implementation 'org.apache.commons:commons-text:1.13.0'
+
     // 유틸리티
     implementation 'org.springframework.boot:spring-boot-starter-validation'
     implementation 'com.fasterxml.jackson.datatype:jackson-datatype-jsr310'

--- a/src/main/java/org/ktb/matajo/config/HTMLCharacterEscapes.java
+++ b/src/main/java/org/ktb/matajo/config/HTMLCharacterEscapes.java
@@ -1,0 +1,34 @@
+package org.ktb.matajo.config;
+
+import com.fasterxml.jackson.core.SerializableString;
+import com.fasterxml.jackson.core.io.CharacterEscapes;
+import com.fasterxml.jackson.core.io.SerializedString;
+import org.apache.commons.text.StringEscapeUtils;
+
+public class HTMLCharacterEscapes extends CharacterEscapes {
+
+    private final int[] asciiEscapes;
+
+    public HTMLCharacterEscapes() {
+
+        // 기본 ASCII 이스케이프 설정 가져오기
+        asciiEscapes = CharacterEscapes.standardAsciiEscapesForJSON();
+
+        // XSS 공격에 사용될 수 있는 문자들 이스케이프 처리 설정
+        asciiEscapes['<'] = CharacterEscapes.ESCAPE_CUSTOM;
+        asciiEscapes['>'] = CharacterEscapes.ESCAPE_CUSTOM;
+        asciiEscapes['&'] = CharacterEscapes.ESCAPE_CUSTOM;
+        asciiEscapes['\"'] = CharacterEscapes.ESCAPE_CUSTOM;
+        asciiEscapes['\''] = CharacterEscapes.ESCAPE_CUSTOM;
+    }
+
+    @Override
+    public int[] getEscapeCodesForAscii() {
+        return asciiEscapes;
+    }
+
+    @Override
+    public SerializableString getEscapeSequence(int i) {
+        return new SerializedString(StringEscapeUtils.escapeHtml4(Character.toString((char) i)));
+    }
+}

--- a/src/main/java/org/ktb/matajo/config/JacksonConfig.java
+++ b/src/main/java/org/ktb/matajo/config/JacksonConfig.java
@@ -47,6 +47,9 @@ public class JacksonConfig {
         // 타임스탬프로 쓰지 않도록 설정
         objectMapper.disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS);
 
+        // HTML 이스케이프 처리를 위한 설정 추가
+        objectMapper.getFactory().setCharacterEscapes(new HTMLCharacterEscapes());
+
         return objectMapper;
     }
 }

--- a/src/main/java/org/ktb/matajo/config/WebConfig.java
+++ b/src/main/java/org/ktb/matajo/config/WebConfig.java
@@ -8,12 +8,12 @@ import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 public class WebConfig implements WebMvcConfigurer {
     @Override
     public void addCorsMappings(CorsRegistry registry) {
-        registry.addMapping("/**")
-                .allowedOrigins("http://localhost:3000", "https://matajo.store")  // 모든 출처 허용
-                .allowedMethods("*")  // 모든 HTTP 메서드 허용
-                .allowedHeaders("*")  // 모든 헤더 허용
-                .allowCredentials(true)
-                .maxAge(3600);        // 브라우저가 preflight 요청 결과를 캐시하는 시간(초)
-
+        registry.addMapping("/**") // 모든 경로에 CORS 설정 적용
+                .allowedOrigins("http://localhost:3000", "https://matajo.store") // 허용할 출처(Origin) 제한
+                .allowedMethods("GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS") // 허용할 HTTP 메서드 지정
+                .allowedHeaders("Authorization", "Content-Type", "X-Requested-With") // 허용할 요청 헤더 지정
+                .exposedHeaders("Authorization") // 클라이언트에서 접근 가능한 응답 헤더 지정
+                .allowCredentials(true) // 인증 정보(쿠키, 인증 헤더) 포함 허용
+                .maxAge(3600); // Preflight 요청 결과 캐시 유지 시간(초)
     }
 }

--- a/src/main/java/org/ktb/matajo/config/WebSocketConfig.java
+++ b/src/main/java/org/ktb/matajo/config/WebSocketConfig.java
@@ -1,9 +1,11 @@
 package org.ktb.matajo.config;
 
+import com.amazonaws.services.s3.AmazonS3Client;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import org.apache.commons.text.StringEscapeUtils;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.messaging.Message;
@@ -33,9 +35,14 @@ import java.nio.charset.StandardCharsets;
 public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
 
     private final ObjectMapper objectMapper;
+    private final AmazonS3Client amazonS3Client;
 
-    public WebSocketConfig(ObjectMapper objectMapper) {
+    @Value("${cloud.aws.s3.url}")
+    private String s3Url;
+
+    public WebSocketConfig(ObjectMapper objectMapper, AmazonS3Client amazonS3Client) {
         this.objectMapper = objectMapper;
+        this.amazonS3Client = amazonS3Client;
     }
 
     /**
@@ -210,10 +217,7 @@ public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
         private boolean isValidImageUrl(String url) {
             // S3 URL 등 허용된 이미지 호스트 확인
             // 프로젝트에 맞게 URL 패턴 수정 필요
-            return url != null && (
-                    url.startsWith("https://your-s3-bucket.s3.amazonaws.com/") ||
-                            url.startsWith("https://matajo.store/api/images/")
-            );
+            return url != null && (url.startsWith(s3Url));
         }
     }
 }

--- a/src/main/java/org/ktb/matajo/config/WebSocketConfig.java
+++ b/src/main/java/org/ktb/matajo/config/WebSocketConfig.java
@@ -1,14 +1,27 @@
 package org.ktb.matajo.config;
 
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import org.apache.commons.text.StringEscapeUtils;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.messaging.Message;
+import org.springframework.messaging.MessageChannel;
 import org.springframework.messaging.simp.config.ChannelRegistration;
 import org.springframework.messaging.simp.config.MessageBrokerRegistry;
+import org.springframework.messaging.simp.stomp.StompCommand;
+import org.springframework.messaging.simp.stomp.StompHeaderAccessor;
+import org.springframework.messaging.support.ChannelInterceptor;
+import org.springframework.messaging.support.MessageBuilder;
+import org.springframework.messaging.support.MessageHeaderAccessor;
 import org.springframework.scheduling.annotation.EnableScheduling;
 import org.springframework.web.socket.config.annotation.EnableWebSocketMessageBroker;
 import org.springframework.web.socket.config.annotation.StompEndpointRegistry;
 import org.springframework.web.socket.config.annotation.WebSocketMessageBrokerConfigurer;
 import org.springframework.web.socket.config.annotation.WebSocketTransportRegistration;
+
+import java.nio.charset.StandardCharsets;
 
 /**
  * WebSocket 설정 클래스
@@ -18,6 +31,12 @@ import org.springframework.web.socket.config.annotation.WebSocketTransportRegist
 @EnableWebSocketMessageBroker  // WebSocket 메시지 브로커 기능 활성화
 @EnableScheduling              // 스케줄링 기능 활성화 (비활성 세션 정리 등에 사용)
 public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
+
+    private final ObjectMapper objectMapper;
+
+    public WebSocketConfig(ObjectMapper objectMapper) {
+        this.objectMapper = objectMapper;
+    }
 
     /**
      * 메시지 브로커 설정
@@ -44,7 +63,7 @@ public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
     @Override
     public void registerStompEndpoints(StompEndpointRegistry registry) {
         registry.addEndpoint("/ws-chat")           // WebSocket 연결 엔드포인트 URL
-                .setAllowedOriginPatterns("*")     // CORS 설정 (운영 환경에서는 구체적인 도메인 지정 권장)
+                .setAllowedOrigins("http://localhost:3000", "https://matajo.store")
                 .withSockJS()                       // SockJS 지원 (WebSocket을 지원하지 않는 브라우저를 위한 폴백)
                 .setSessionCookieNeeded(false)      // 세션 쿠키 사용 안 함
                 .setHeartbeatTime(25000)            // 하트비트 시간 설정 (ms) - 연결 유지 확인
@@ -66,6 +85,7 @@ public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
     /**
      * 클라이언트 인바운드 채널 설정
      * 클라이언트에서 서버로 들어오는 메시지 처리를 위한 스레드 풀 구성
+     * XSS 방지 인터셉터 추가
      */
     @Override
     public void configureClientInboundChannel(ChannelRegistration registration) {
@@ -73,6 +93,9 @@ public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
                 .corePoolSize(2)       // 기본 스레드 수
                 .maxPoolSize(8)        // 최대 스레드 수
                 .queueCapacity(100);   // 작업 큐 용량
+
+        // XSS 방지 인터셉터 추가 - JacksonConfig의 ObjectMapper 주입
+        registration.interceptors(new XssProtectionChannelInterceptor(objectMapper));
     }
 
     /**
@@ -89,11 +112,108 @@ public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
 
     /**
      * 세션 정리 기능을 위한 스케줄러 빈 등록
-     * SessionCleanupScheduler가 WebSocketEventListener에 의존하지만,
-     * WebSocketConfig는 이제 WebSocketEventListener에 직접 의존하지 않습니다.
      */
     @Bean
     public SessionCleanupScheduler sessionCleanupScheduler(WebSocketEventListener eventListener) {
         return new SessionCleanupScheduler(eventListener);
+    }
+
+    /**
+     * WebSocket 메시지에 대한 XSS 보호 인터셉터
+     * 정적 클래스가 아닌 일반 내부 클래스로 변경
+     */
+    private class XssProtectionChannelInterceptor implements ChannelInterceptor {
+        private final ObjectMapper objectMapper;
+
+        public XssProtectionChannelInterceptor(ObjectMapper objectMapper) {
+            this.objectMapper = objectMapper;
+        }
+
+        @Override
+        public Message<?> preSend(Message<?> message, MessageChannel channel) {
+            StompHeaderAccessor accessor = MessageHeaderAccessor.getAccessor(message, StompHeaderAccessor.class);
+
+            if (accessor != null && StompCommand.SEND.equals(accessor.getCommand())) {
+                // STOMP SEND 명령인 경우 (클라이언트→서버 메시지)
+                Object payload = message.getPayload();
+
+                if (payload instanceof byte[]) {
+                    try {
+                        // 메시지 페이로드 파싱
+                        String messageContent = new String((byte[]) payload, StandardCharsets.UTF_8);
+
+                        // 메시지 타입에 따라 다른 처리 적용
+                        String destination = accessor.getDestination();
+                        if (destination != null && destination.startsWith("/app/chat/")) {
+                            // 채팅 메시지인 경우 필터링 적용
+                            return sanitizeChatMessage(messageContent, accessor, message);
+                        }
+                    } catch (Exception e) {
+                        // 예외 발생 시 로깅하고 원본 메시지 반환
+                        System.err.println("메시지 처리 중 예외 발생: " + e.getMessage());
+                        e.printStackTrace();
+                        return message;
+                    }
+                }
+            }
+
+            return message;
+        }
+
+        /**
+         * 채팅 메시지 내용 필터링
+         */
+        private Message<?> sanitizeChatMessage(String messageContent,
+                                               StompHeaderAccessor accessor,
+                                               Message<?> originalMessage) {
+            try {
+                // JSON 파싱
+                JsonNode rootNode = objectMapper.readTree(messageContent);
+
+                // messageType 확인 (TEXT, IMAGE, SYSTEM)
+                String messageType = rootNode.path("messageType").asText();
+
+                // 필터링 적용
+                ObjectNode modifiedNode = (ObjectNode) rootNode;
+
+                if ("TEXT".equals(messageType)) {
+                    // 텍스트 메시지는 HTML 이스케이프 처리
+                    String content = rootNode.path("content").asText();
+                    String sanitized = StringEscapeUtils.escapeHtml4(content);
+                    modifiedNode.put("content", sanitized);
+                } else if ("IMAGE".equals(messageType)) {
+                    // 이미지 메시지는 URL 검증
+                    String imageUrl = rootNode.path("content").asText();
+                    if (!isValidImageUrl(imageUrl)) {
+                        // 유효하지 않은 URL은 빈 문자열로 대체
+                        modifiedNode.put("content", "");
+                    }
+                }
+
+                // 필터링된 메시지로 교체
+                String sanitizedContent = objectMapper.writeValueAsString(modifiedNode);
+                return MessageBuilder.createMessage(
+                        sanitizedContent.getBytes(StandardCharsets.UTF_8),
+                        accessor.getMessageHeaders()
+                );
+            } catch (Exception e) {
+                // 예외 발생 시 상세 로깅 및 원본 메시지 반환
+                System.err.println("채팅 메시지 필터링 중 오류 발생: " + e.getMessage());
+                e.printStackTrace();
+                return originalMessage;
+            }
+        }
+
+        /**
+         * 이미지 URL 유효성 검증
+         */
+        private boolean isValidImageUrl(String url) {
+            // S3 URL 등 허용된 이미지 호스트 확인
+            // 프로젝트에 맞게 URL 패턴 수정 필요
+            return url != null && (
+                    url.startsWith("https://your-s3-bucket.s3.amazonaws.com/") ||
+                            url.startsWith("https://matajo.store/api/images/")
+            );
+        }
     }
 }


### PR DESCRIPTION
### Description

  HTML 이스케이프 처리 관련 의존성을 추가하고, 문자열 이스케이프/언이스케이프 기능을 구현하였습니다.
  또한 CORS 설정을 업데이트하여 허용 출처와 HTTP 메소드를 명확히 지정했습니다.

### Changes Made
<!--
  이 PR에서 변경된 사항을 설명하세요.
-->
1. Apache Commons Text 의존성 추가 (문자열 이스케이프 처리용)
2. 문자열 이스케이프 및 언이스케이프 기능 구현
3. CORS 설정 업데이트: 허용 출처(localhost:3000, matajo.store) 및 HTTP 메소드 명시적 지정
4. WebConfig에서 CORS 관련 설정 개선


### Checklist
<!--
  PR 작성 시 다음 항목들을 확인하세요.
-->
- [x] 코드가 정상적으로 컴파일되는지 확인했습니다.
- [x] 모든 테스트가 성공적으로 통과했습니다.
- [x] 코드 스타일 가이드라인을 준수했습니다.
- [x] 코드 리뷰어를 지정했습니다.

### Additional Notes
<!--
  리뷰어가 이해하는 데 도움이 될 추가적인 참고 사항이나 정보가 있다면 여기에 작성하세요.
-->
이 PR은 XSS 취약점 방지를 위한 추가 보안 계층을 구현합니다. 이미 `HTMLCharacterEscapes`와 `XssProtectionChannelInterceptor`가 구현되어 있지만, 특정 상황에서 추가적인 이스케이프 처리가 필요한 경우를 대비해 유틸리티 메소드를 제공합니다.