### PR TITLE
feat: API 요청에 대한 Rate Limiting 기능 추가

### DIFF
--- a/src/main/java/org/ktb/matajo/config/RateLimitConfig.java
+++ b/src/main/java/org/ktb/matajo/config/RateLimitConfig.java
@@ -1,0 +1,71 @@
+package org.ktb.matajo.config;
+
+import io.github.bucket4j.Bandwidth;
+import io.github.bucket4j.Bucket;
+import io.github.bucket4j.Refill;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.annotation.Configuration;
+
+import java.time.Duration;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+@Slf4j
+@Configuration
+public class RateLimitConfig {
+
+    // 클라이언트 ID별 버킷을 저장할 Map (메모리 기반)
+    private final Map<String, Bucket> bucketCache = new ConcurrentHashMap<>();
+
+    // API 유형별 버킷 정책 정의
+    public enum ApiType {
+        GENERAL,    // 일반 API
+        AUTH,       // 인증 관련 API
+        CHAT,       // 채팅 관련 API
+        POST,       // 게시글
+        LOCATION    // 메인 주소 관련 API
+    }
+    
+    /**
+     * 클라이언트 ID와 API 유형에 따른 버킷 반환
+     * 버킷이 없으면 새로 생성하여 반환
+     */
+    public Bucket resolveBucket(Long clientId, ApiType apiType) {
+        String key = clientId + ":" + apiType.name();
+        return bucketCache.computeIfAbsent(key, k -> createBucket(apiType));
+    }
+    
+    /**
+     * API 유형별 버킷 생성
+     */
+    private Bucket createBucket(ApiType apiType) {
+        Bandwidth limit;
+        
+        switch (apiType) {
+            case AUTH:
+                // 인증 요청: 1분에 5회
+                limit = Bandwidth.classic(5, Refill.intervally(5, Duration.ofMinutes(1)));
+                break;
+            case CHAT:
+                // 채팅 요청: 1분에 60회
+                limit = Bandwidth.classic(60, Refill.intervally(60, Duration.ofMinutes(1)));
+                break;
+            case POST:
+                // 게시글 요청: 1분에 50회
+                limit = Bandwidth.classic(50, Refill.intervally(50, Duration.ofMinutes(1)));
+            break;
+            case LOCATION:
+                // 주소 요청: 1분에 100회
+                limit = Bandwidth.classic(100, Refill.intervally(100, Duration.ofMinutes(1)));
+                break;
+            case GENERAL:
+            default:
+                // 일반 API 요청: 1분에 10회
+                limit = Bandwidth.classic(10, Refill.intervally(10, Duration.ofMinutes(1)));
+                break;
+        }
+        
+        return Bucket.builder().addLimit(limit).build();
+    }
+
+}

--- a/src/main/java/org/ktb/matajo/config/WebConfig.java
+++ b/src/main/java/org/ktb/matajo/config/WebConfig.java
@@ -1,11 +1,19 @@
 package org.ktb.matajo.config;
 
+import lombok.RequiredArgsConstructor;
+import org.ktb.matajo.interceptor.RateLimitInterceptor;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.web.servlet.config.annotation.CorsRegistry;
+import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 
 @Configuration
+@RequiredArgsConstructor
+
 public class WebConfig implements WebMvcConfigurer {
+
+    private final RateLimitInterceptor rateLimitInterceptor;
+
     @Override
     public void addCorsMappings(CorsRegistry registry) {
         registry.addMapping("/**")
@@ -15,5 +23,15 @@ public class WebConfig implements WebMvcConfigurer {
                 .allowCredentials(true)
                 .maxAge(3600);        // 브라우저가 preflight 요청 결과를 캐시하는 시간(초)
 
+    }
+
+    @Override
+    public void addInterceptors(InterceptorRegistry registry){
+        registry.addInterceptor(rateLimitInterceptor)
+            .addPathPatterns("/**") //모든 경로 적용
+            .excludePathPatterns(
+                "/swagger-ui/**", //API 문서 제외
+                "/v3/api-docs/**" // API 문서 제외
+            );
     }
 }

--- a/src/main/java/org/ktb/matajo/global/error/code/ErrorCode.java
+++ b/src/main/java/org/ktb/matajo/global/error/code/ErrorCode.java
@@ -58,6 +58,9 @@ public enum ErrorCode {
     // 409 CONFLICT
     CHAT_USER_ALREADY_LEFT(HttpStatus.CONFLICT, "chat_user_already_left", "이미 채팅방을 나간 사용자입니다"),
 
+    //429 TOO_MANY_REQUESTS
+    TOO_MANY_REQUESTS(HttpStatus.TOO_MANY_REQUESTS,"too_many_requests", "요청 한도를 초과했습니다. 잠시 후 다시 시도해주세요."),
+
     // 500 INTERNAL SERVER ERROR
     INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "internal_server_error", "서버 내부 오류가 발생했습니다"),
     FAILED_TO_UPLOAD_IMAGE(HttpStatus.INTERNAL_SERVER_ERROR, "failed_to_upload_image", "이미지 업로드에 실패했습니다"),

--- a/src/main/java/org/ktb/matajo/global/error/exception/GlobalExceptionHandler.java
+++ b/src/main/java/org/ktb/matajo/global/error/exception/GlobalExceptionHandler.java
@@ -40,7 +40,7 @@ public class GlobalExceptionHandler {
         // 응답 생성 및 반환 (data 필드 없음)
         return ResponseEntity
                 .status(errorCode.getStatus())
-                .body(CommonResponse.error(errorCode.getDescription(),null));
+                .body(CommonResponse.error(errorCode.getErrorMessage(),null));
     }
 
     /**

--- a/src/main/java/org/ktb/matajo/interceptor/RateLimitInterceptor.java
+++ b/src/main/java/org/ktb/matajo/interceptor/RateLimitInterceptor.java
@@ -1,0 +1,103 @@
+package org.ktb.matajo.interceptor;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.github.bucket4j.Bucket;
+import io.github.bucket4j.ConsumptionProbe;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.ktb.matajo.config.RateLimitConfig;
+import org.ktb.matajo.config.RateLimitConfig.ApiType;
+import org.ktb.matajo.global.common.ErrorResponse;
+import org.ktb.matajo.global.error.code.ErrorCode;
+import org.ktb.matajo.global.error.exception.BusinessException;
+import org.ktb.matajo.security.SecurityUtil;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.stereotype.Component;
+import org.springframework.web.servlet.HandlerInterceptor;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.nio.charset.StandardCharsets;
+import java.util.concurrent.TimeUnit;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class RateLimitInterceptor implements HandlerInterceptor {
+
+    private final RateLimitConfig rateLimitConfig;
+    private final ObjectMapper objectMapper;
+
+    @Override
+    public boolean preHandle(HttpServletRequest request, HttpServletResponse response, Object handler) throws Exception {
+        // API 경로에 따라 API 유형 결정
+        ApiType apiType = resolveApiType(request.getRequestURI());
+        
+        // 클라이언트 식별자 가져오기
+        Long clientId = SecurityUtil.getCurrentUserId();
+        
+        // 클라이언트 ID와 API 유형에 따른 버킷 가져오기
+        Bucket bucket = rateLimitConfig.resolveBucket(clientId, apiType);
+        
+        // 토큰 소비 시도
+        ConsumptionProbe probe = bucket.tryConsumeAndReturnRemaining(1);
+        
+        // Rate Limit 관련 헤더 추가
+        response.addHeader("X-RateLimit-Limit", String.valueOf(getLimitForApiType(apiType)));
+        response.addHeader("X-RateLimit-Remaining", String.valueOf(probe.getRemainingTokens()));
+        
+        if (probe.isConsumed()) {
+            //요청 허용
+            return true;
+        } else {
+            // 요청 차단 (429 Too Many Requests)
+            long waitTimeSeconds = TimeUnit.NANOSECONDS.toSeconds(probe.getNanosToWaitForRefill());
+            response.addHeader("X-RateLimit-Reset", String.valueOf(waitTimeSeconds));
+            response.setStatus(HttpStatus.TOO_MANY_REQUESTS.value());
+            response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+            response.setCharacterEncoding(StandardCharsets.UTF_8.name());
+            
+            
+            log.warn("Rate limit exceeded for client: {}, API type: {}, wait time: {}s", 
+                    clientId, apiType, waitTimeSeconds);
+            
+            // 비즈니스 예외 던지기
+            throw new BusinessException(ErrorCode.TOO_MANY_REQUESTS);
+
+            //return false;
+        }
+
+    }
+    
+    /**
+     * API 경로에 따른 API 유형 결정
+     */
+    private ApiType resolveApiType(String uri) {
+        if (uri.startsWith("/auth")) {
+            return ApiType.AUTH;
+        } else if (uri.startsWith("/chats")) {
+            return ApiType.CHAT;
+        } else if (uri.contains("/locations")) {
+            return ApiType.LOCATION;
+        } else if (uri.contains("/posts")) {
+            return ApiType.POST;
+        } else {
+            return ApiType.GENERAL;
+        }
+    }
+    
+    /**
+     * API 유형별 제한 횟수 반환
+     */
+    private int getLimitForApiType(ApiType apiType) {
+        switch (apiType) {
+            case AUTH: return 5;
+            case CHAT: return 60;
+            case POST: return 50;
+            case LOCATION: return 100;
+            case GENERAL:
+            default: return 10;
+        }
+    }
+}

--- a/src/main/java/org/ktb/matajo/interceptor/RateLimitInterceptor.java
+++ b/src/main/java/org/ktb/matajo/interceptor/RateLimitInterceptor.java
@@ -53,7 +53,7 @@ public class RateLimitInterceptor implements HandlerInterceptor {
         } else {
             // 요청 차단 (429 Too Many Requests)
             long waitTimeSeconds = TimeUnit.NANOSECONDS.toSeconds(probe.getNanosToWaitForRefill());
-            response.addHeader("X-RateLimit-Reset", String.valueOf(waitTimeSeconds));
+            response.addHeader("Retry-After", String.valueOf(waitTimeSeconds));
             response.setStatus(HttpStatus.TOO_MANY_REQUESTS.value());
             response.setContentType(MediaType.APPLICATION_JSON_VALUE);
             response.setCharacterEncoding(StandardCharsets.UTF_8.name());


### PR DESCRIPTION
### Description

- RateLimitConfig 클래스를 새로 생성하여 클라이언트 ID와 API 유형에 따른 요청 제한을 설정
- RateLimitInterceptor 클래스를 추가하여 API 요청 시 Rate Limiting을 적용
- WebConfig 클래스에 RateLimitInterceptor를 등록하여 모든 API 경로에 대해 적용
- ErrorCode에 TOO_MANY_REQUESTS 추가하여 요청 한도 초과 시 적절한 에러 메시지 반환

### Related Issues


- Resolves #[이슈 번호]

### Changes Made

1. (+) RateLimitInterceptor
2. (+) RateLimitConfig
3.  (수정) WebConfig


### Testing

postman으로 테스트

### Checklist
- [ ] 코드가 정상적으로 컴파일되는지 확인했습니다.
- [ ] 모든 테스트가 성공적으로 통과했습니다.
- [ ] 관련 문서를 업데이트했습니다.
- [ ] PR이 관련 이슈를 정확히 참조하고 있습니다.
- [ ] 코드 스타일 가이드라인을 준수했습니다.
- [ ] 코드 리뷰어를 지정했습니다.

### Additional Notes

