### PR TITLE
feat: SwaggerConfig 클래스에 JWT 인증 방식 추가

### DIFF
--- a/src/main/java/org/ktb/matajo/config/SwaggerConfig.java
+++ b/src/main/java/org/ktb/matajo/config/SwaggerConfig.java
@@ -3,19 +3,38 @@ package org.ktb.matajo.config;
 import io.swagger.v3.oas.models.OpenAPI;
 import io.swagger.v3.oas.models.info.Info;
 import io.swagger.v3.oas.models.servers.Server;
+import io.swagger.v3.oas.models.Components;
+import io.swagger.v3.oas.models.security.SecurityRequirement;
+import io.swagger.v3.oas.models.security.SecurityScheme;
+
+import io.swagger.v3.oas.annotations.enums.SecuritySchemeType;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
 @Configuration
+@io.swagger.v3.oas.annotations.security.SecurityScheme( // 👈 어노테이션은 경로 전체 사용
+    name = "Bearer Authentication",
+    type = SecuritySchemeType.HTTP,
+    bearerFormat = "JWT",
+    scheme = "bearer"
+)
 public class SwaggerConfig {
-    
+
     @Bean
     public OpenAPI openAPI() {
         return new OpenAPI()
-                .info(new Info()
-                        .title("Matajo API 문서")
-                        .description("Matajo 서비스의 API 명세서입니다.")
-                        .version("v1.0.0"))
-                .addServersItem(new Server().url("/"));
+            .addSecurityItem(new SecurityRequirement().addList("Bearer Authentication"))
+            .components(new Components()
+                .addSecuritySchemes("Bearer Authentication",
+                    new SecurityScheme()
+                        .name("Bearer Authentication")
+                        .type(SecurityScheme.Type.HTTP)
+                        .scheme("bearer")
+                        .bearerFormat("JWT")))
+            .info(new Info()
+                .title("Matajo API 문서")
+                .description("Matajo 서비스의 API 명세서입니다.")
+                .version("v1.0.0"))
+            .addServersItem(new Server().url("/"));
     }
-} 
+}


### PR DESCRIPTION
### Description

- SwaggerConfig 클래스에 Bearer Authentication을 위한 보안 스킴을 추가하여 JWT 인증 방식을 지원함.
- OpenAPI 설정에서 보안 요구 사항 및 구성 요소를 추가하여 API 문서화 시 인증 정보를 명확히 함.
- 기존 API 문서 정보는 유지하며, 서버 URL 설정도 포함됨.

### Related Issues


### Changes Made

1. SwaggerConfig

### Screenshots or Video


### Testing

### Checklist


### Additional Notes


