### PR TITLE
feat: 게시글 응답 DTO에 id 필드 추가

### DIFF
--- a/src/main/java/org/ktb/matajo/dto/location/LocationDealResponseDto.java
+++ b/src/main/java/org/ktb/matajo/dto/location/LocationDealResponseDto.java
@@ -13,6 +13,10 @@ import lombok.NoArgsConstructor;
 @Builder
 @Schema(description = "위치 기반 할인 정보 응답 DTO")
 public class LocationDealResponseDto {
+
+    @Schema(description = "게시글 id")
+    private Long id;
+
     @Schema(description = "게시글 제목", example = "아이패드 보관 맡겨주세요")
     private String title;
 

--- a/src/main/java/org/ktb/matajo/service/post/PostServiceImpl.java
+++ b/src/main/java/org/ktb/matajo/service/post/PostServiceImpl.java
@@ -741,6 +741,7 @@ public class PostServiceImpl implements PostService {
         // DTO 변환
         List<LocationDealResponseDto> dealResponses = topDiscountedPosts.stream()
             .map(post -> LocationDealResponseDto.builder()
+                .id(post.getId())
                 .title(post.getTitle())
                 .discount(String.format("-%d%%", Math.round(post.getDiscountRate())))
                 .imageUrl(post.getImageList().stream()


### PR DESCRIPTION
### Description

게시글 응답 DTO인 LocationDealResponseDto에 게시글 id 필드를 추가 이로 인해 게시글의 고유 식별자를 포함할 수 있게 되어, 클라이언트에서 게시글을 보다 쉽게 식별하고 처리 가능 또한, PostServiceImpl에서 DTO 변환 시 해당 id를 설정하도록 수정

### Related Issues



### Changes Made

1. PostController id 수정

### Screenshots or Video


### Testing


### Checklist
- [ ] 코드가 정상적으로 컴파일되는지 확인했습니다.
- [ ] 모든 테스트가 성공적으로 통과했습니다.
- [ ] 관련 문서를 업데이트했습니다.
- [ ] PR이 관련 이슈를 정확히 참조하고 있습니다.
- [ ] 코드 스타일 가이드라인을 준수했습니다.
- [ ] 코드 리뷰어를 지정했습니다.

### Additional Notes
