### PR TITLE
fix: 게시글 응답 DTO에 ID 추가

### DIFF
--- a/src/main/java/org/ktb/matajo/service/post/PostServiceImpl.java
+++ b/src/main/java/org/ktb/matajo/service/post/PostServiceImpl.java
@@ -742,6 +742,7 @@ public class PostServiceImpl implements PostService {
         // DTO 변환
         List<LocationDealResponseDto> dealResponses = topDiscountedPosts.stream()
                 .map(post -> LocationDealResponseDto.builder()
+                        .id(post.getId())
                         .title(post.getTitle())
                         .discount(String.format("-%d%%", Math.round(post.getDiscountRate())))
                         .imageUrl(post.getImageList().stream()


### PR DESCRIPTION

### Description

게시글 목록 응답 DTO인 LocationDealResponseDto에 게시글 ID를 추가
-> merge 중 코드가 삭제됨. 다시 수정

### Related Issues

#136 

### Changes Made

PostServiceImpl 특가조회 id 추가

### Screenshots or Video


### Testing]

### Checklist
- [ ] 코드가 정상적으로 컴파일되는지 확인했습니다.
- [ ] 모든 테스트가 성공적으로 통과했습니다.
- [ ] 관련 문서를 업데이트했습니다.
- [ ] PR이 관련 이슈를 정확히 참조하고 있습니다.
- [ ] 코드 스타일 가이드라인을 준수했습니다.
- [ ] 코드 리뷰어를 지정했습니다.

### Additional Notes
