### PR TITLE
feat: 게시글 목록 조회 기능 개선 및 태그 필터링 추가

### DIFF
--- a/src/main/java/org/ktb/matajo/entity/Tag.java
+++ b/src/main/java/org/ktb/matajo/entity/Tag.java
@@ -20,6 +20,10 @@ public class Tag {
     //태그 이름
     @Column(nullable = false, length = 20, unique = true)
     private String tagName;
+    
+    //태그 카테고리
+    @Column(nullable = false)
+    private Long tagCategoryId;
 
     @Builder.Default
     @OneToMany(mappedBy = "tag", cascade = CascadeType.ALL)

--- a/src/main/java/org/ktb/matajo/global/error/code/ErrorCode.java
+++ b/src/main/java/org/ktb/matajo/global/error/code/ErrorCode.java
@@ -17,6 +17,7 @@ public enum ErrorCode {
     INVALID_PREFER_PRICE(HttpStatus.BAD_REQUEST, "invalid_prefer_price", "선호 가격이 유효하지 않습니다"),
     INVALID_LOCATION_ID(HttpStatus.BAD_REQUEST, "invalid_location_id", "올바르지 않은 위치 정보입니다"),
     INVALID_USER_ID(HttpStatus.BAD_REQUEST, "invalid_user_id", "사용자 ID가 유효하지 않습니다"),
+    INVALID_TAG_ID(HttpStatus.BAD_REQUEST, "invalid_tag_id", "태그 ID가 유효하지 않습니다"),
     INVALID_CHAT_ROOM_ID(HttpStatus.BAD_REQUEST, "invalid_chat_room_id", "채팅방 ID가 유효하지 않습니다"),
     INVALID_IMAGE_CONTENT(HttpStatus.BAD_REQUEST, "invalid_image_content", "이미지 타입 메시지의 내용이 비어있습니다"),
     INVALID_IMAGE_URL(HttpStatus.BAD_REQUEST, "invalid_image_url", "이미지 URL이 유효하지 않습니다"),

--- a/src/main/java/org/ktb/matajo/repository/PostRepository.java
+++ b/src/main/java/org/ktb/matajo/repository/PostRepository.java
@@ -12,7 +12,11 @@ import java.util.List;
 @Repository
 public interface PostRepository extends JpaRepository<Post, Long> {
 
-    @Query("SELECT p FROM Post p WHERE p.deletedAt IS NULL AND p.hiddenStatus = false ORDER BY p.createdAt DESC")
+    @Query("SELECT p " +
+           "FROM Post p " +
+           "WHERE p.deletedAt IS NULL " +
+           "AND p.hiddenStatus = false " +
+           "ORDER BY p.createdAt DESC")
     List<Post> findAllActivePostsOrderByCreatedAtDesc(Pageable pageable);
 
     // location_info_id로 게시글 직접 조회 (단일 쿼리로 처리)
@@ -46,4 +50,23 @@ public interface PostRepository extends JpaRepository<Post, Long> {
             "AND p.deletedAt IS NULL " +
             "ORDER BY p.createdAt DESC")
     List<Post> findByUserId(@Param("userId") Long userId, Pageable pageable);
+
+    /**
+     * 태그 ID 리스트로 게시글 ID 찾기 (카테고리 고려)
+     */
+    @Query("SELECT DISTINCT p.id FROM Post p " +
+           "JOIN p.postTagList pt " +
+           "JOIN pt.tag t " +
+           "WHERE t.id IN :tagIds")
+    List<Long> findPostIdsByTagIds(@Param("tagIds") List<Long> tagIds);
+    
+    /**
+     * 게시글 ID 리스트로 게시글 조회
+     */
+    @Query("SELECT p FROM Post p " +
+           "WHERE p.id IN :postIds " +
+           "AND p.deletedAt IS NULL " +
+           "AND p.hiddenStatus = false " +
+           "ORDER BY p.createdAt DESC")
+    List<Post> findByPostIds(@Param("postIds") List<Long> postIds, Pageable pageable);
 }

--- a/src/main/java/org/ktb/matajo/repository/TagRepository.java
+++ b/src/main/java/org/ktb/matajo/repository/TagRepository.java
@@ -2,6 +2,8 @@ package org.ktb.matajo.repository;
 
 import org.ktb.matajo.entity.Tag;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import io.lettuce.core.dynamic.annotation.Param;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
@@ -12,6 +14,8 @@ public interface TagRepository extends JpaRepository<Tag,Long> {
     //태그 이름으로 태그 찾기
     Optional<Tag> findByTagName(String tagName);
 
-    //태그 이름 포함 검색 (검색 기능)
-    List<Tag> findByTagNameContaining(String keyword);
+    
+    //태그 이름 목록으로 태그 정보 조회
+    List<Tag> findByTagNameIn(List<String> tagNames);
+
 }

--- a/src/main/java/org/ktb/matajo/service/post/PostService.java
+++ b/src/main/java/org/ktb/matajo/service/post/PostService.java
@@ -70,4 +70,15 @@ public interface PostService {
   
   // 내 보관소 조회
   List<PostResponseDto> getMyPosts(Long userId, int offset, int limit);
+
+  
+  /**
+   * 카테고리별 태그 필터링 기반 게시글 목록 조회
+   * 각 카테고리 내 태그는 OR 조건, 카테고리 간 태그는 AND 조건으로 필터링
+   * @param tagNames 필터링할 태그 이름 목록
+   * @param offset 시작 오프셋
+   * @param limit 조회할 게시글 수
+   * @return 카테고리 기반 태그 필터링된 게시글 목록
+   */
+  List<PostListResponseDto> getPostsByTagsWithCategoryLogic(List<String> tagNames, int offset, int limit);
 }

--- a/src/main/java/org/ktb/matajo/service/post/PostServiceImpl.java
+++ b/src/main/java/org/ktb/matajo/service/post/PostServiceImpl.java
@@ -1,5 +1,6 @@
 package org.ktb.matajo.service.post;
 
+import java.util.HashSet;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.ktb.matajo.dto.location.LocationDealResponseDto;
@@ -20,6 +21,8 @@ import org.springframework.transaction.annotation.Transactional;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.Map;
+import java.util.Set;
 import java.util.stream.Collectors;
 
 @Slf4j
@@ -775,6 +778,102 @@ public class PostServiceImpl implements PostService {
                         .createdAt(post.getCreatedAt())
                         .build())
                 .collect(Collectors.toList());
+    }
+
+    /**
+     * 카테고리별 태그 필터링 기반 게시글 목록 조회
+     * 각 카테고리 내 태그는 OR 조건, 카테고리 간 태그는 AND 조건으로 필터링
+     */
+    @Override
+    public List<PostListResponseDto> getPostsByTagsWithCategoryLogic(List<String> tagNames, int offset, int limit) {
+        // 요청 파라미터 검증
+        if (offset < 0 || limit <= 0) {
+            throw new BusinessException(ErrorCode.INVALID_OFFSET_OR_LIMIT);
+        }
+        
+        if (tagNames == null || tagNames.isEmpty()) {
+            log.info("태그 필터가 없어 일반 게시글 목록을 반환합니다.");
+            return getPostList(offset, limit);
+        }
+        
+        log.info("카테고리 기반 태그 필터링 시작: tags={}, offset={}, limit={}", tagNames, offset, limit);
+        
+        try {
+            // 1. 태그 이름 목록으로 태그 정보 조회
+            List<Tag> tags = tagRepository.findByTagNameIn(tagNames);
+            if (tags.isEmpty()) {
+                log.info("유효한 태그가 없습니다: tagNames={}", tagNames);
+                return Collections.emptyList();
+            }
+            
+            // 2. 태그를 카테고리별로 그룹화
+            Map<Long, List<Tag>> tagsByCategory = tags.stream()
+                    .collect(Collectors.groupingBy(Tag::getTagCategoryId));
+            
+            log.info("카테고리별 태그 그룹화: {}", tagsByCategory.keySet());
+            
+            // 3. 초기 결과 집합으로 사용할 게시글 ID 집합 (아직 미설정)
+            Set<Long> resultPostIds = null;
+            
+            // 4. 각 카테고리별로 OR 조건으로 게시글 찾고, 카테고리 간에는 AND 조건 적용
+            for (Map.Entry<Long, List<Tag>> entry : tagsByCategory.entrySet()) {
+                Long categoryId = entry.getKey();
+                List<Tag> categoryTags = entry.getValue();
+                
+                // 카테고리 내 태그 ID 목록
+                List<Long> categoryTagIds = categoryTags.stream()
+                        .map(Tag::getId)
+                        .collect(Collectors.toList());
+                
+                log.debug("카테고리 {} 태그 ID: {}", categoryId, categoryTagIds);
+                
+                // 카테고리 내 태그가 포함된 게시글 ID 조회 (OR 조건)
+                List<Long> categoryPostIds = postRepository.findPostIdsByTagIds(categoryTagIds);
+                
+                if (categoryPostIds.isEmpty()) {
+                    // 해당 카테고리의 태그를 가진 게시글이 없으면 최종 결과도 없음 (AND 조건)
+                    log.info("카테고리 {}의 태그를 가진 게시글이 없습니다", categoryId);
+                    return Collections.emptyList();
+                }
+                
+                // 결과 집합 초기화 또는 교집합 처리 (AND 조건)
+                if (resultPostIds == null) {
+                    resultPostIds = new HashSet<>(categoryPostIds);
+                } else {
+                    resultPostIds.retainAll(categoryPostIds); // 교집합 구하기
+                    
+                    // 교집합 이후 결과가 없으면 즉시 반환
+                    if (resultPostIds.isEmpty()) {
+                        log.info("모든 카테고리 조건을 만족하는 게시글이 없습니다");
+                        return Collections.emptyList();
+                    }
+                }
+            }
+            
+            // 결과가 없으면 빈 목록 반환
+            if (resultPostIds == null || resultPostIds.isEmpty()) {
+                log.info("필터링 조건을 만족하는 게시글이 없습니다");
+                return Collections.emptyList();
+            }
+            
+            log.info("카테고리 필터링 후 게시글 수: {}", resultPostIds.size());
+            
+            // 5. 최종 결과 게시글 ID로 게시글 조회 (페이징 적용)
+            Pageable pageable = PageRequest.of(offset, limit);
+            List<Post> posts = postRepository.findByPostIds(new ArrayList<>(resultPostIds), pageable);
+            
+            // 6. 엔티티를 DTO로 변환
+            List<PostListResponseDto> result = posts.stream()
+                    .map(this::convertToPostResponseDto)
+                    .collect(Collectors.toList());
+            
+            log.info("카테고리 기반 태그 필터링 완료: 결과 게시글 수={}", result.size());
+            
+            return result;
+        } catch (Exception e) {
+            log.error("카테고리별 태그 필터링 중 오류 발생: {}", e.getMessage(), e);
+            throw new BusinessException(ErrorCode.INVALID_INPUT_VALUE);
+        }
     }
 
 }


### PR DESCRIPTION
### Description

- 게시글 목록 조회 API에 태그 필터링 기능을 추가하였습니다. 사용자가 요청 시 태그 목록을 제공하면, 해당 태그에 따라 게시글을 카테고리별로 필터링하여 반환
- 태그는 카테고리 내에서 OR 조건으로, 카테고리 간에는 AND 조건으로 처리
- 태그 카테고리 ID를 Tag 엔티티에 추가하였으며, 관련된 리포지토리 메서드도 구현
- 게시글 조회 시 태그 필터링이 없을 경우 기존 방식으로 게시글을 반환


### Related Issues



### Changes Made
1. [변경 내용 1]
2. [변경 내용 2]
3. [변경 내용 3]

### Screenshots or Video


### Testing
1. [테스트 1]
2. [테스트 2]
3. [테스트 3]

### Checklist
- [ ] 코드가 정상적으로 컴파일되는지 확인했습니다.
- [ ] 모든 테스트가 성공적으로 통과했습니다.
- [ ] 관련 문서를 업데이트했습니다.
- [ ] PR이 관련 이슈를 정확히 참조하고 있습니다.
- [ ] 코드 스타일 가이드라인을 준수했습니다.
- [ ] 코드 리뷰어를 지정했습니다.

### Additional Notes
