### PR TITLE
[feat] 위치 기반 보관소 조회 API 추가

### DIFF
--- a/src/main/java/org/ktb/matajo/controller/PostController.java
+++ b/src/main/java/org/ktb/matajo/controller/PostController.java
@@ -13,6 +13,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.ktb.matajo.dto.location.LocationDealResponseDto;
 import org.ktb.matajo.dto.location.LocationPostResponseDto;
 import org.ktb.matajo.dto.post.*;
+import org.ktb.matajo.dto.storage.StorageResponseDto;
 import org.ktb.matajo.entity.Storage;
 import org.ktb.matajo.global.common.CommonResponse;
 import org.ktb.matajo.global.common.ErrorResponse;
@@ -26,6 +27,7 @@ import org.springframework.web.bind.annotation.*;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
 
 @Tag(name = "게시글 API", description = "게시글 CRUD 및 관련 기능을 제공하는 API")
 @Slf4j
@@ -286,13 +288,22 @@ public class PostController {
 
     @Operation(summary = "위치 기반 보관소 조회", description = "특정 동네의 보관소 목록을 조회합니다.")
     @GetMapping("/location/storages")
-    public ResponseEntity<CommonResponse<List<Storage>>> getStoragesByLocation(
+    public ResponseEntity<CommonResponse<List<StorageResponseDto>>> getStoragesByLocation(
             @RequestParam("locationInfoId") Long locationInfoId) {
 
         log.info("위치 기반 보관소 조회 요청: locationInfoId={}", locationInfoId);
 
-        List<Storage> storages = storageRepository.findByLocationInfoId(locationInfoId);
-        return ResponseEntity.ok(CommonResponse.success("get_storages_success", storages));
+        List<StorageResponseDto> dtoList = storageRepository.findByLocationInfoId(locationInfoId)
+                .stream()
+                .map(storage -> new StorageResponseDto(
+                        storage.getId(),
+                        storage.getKakaoMapLink(),
+                        storage.getName(),
+                        storage.getLocationInfoId()
+                ))
+                .collect(Collectors.toList());
+
+        return ResponseEntity.ok(CommonResponse.success("get_storages_success", dtoList));
     }
 
 }

--- a/src/main/java/org/ktb/matajo/controller/PostController.java
+++ b/src/main/java/org/ktb/matajo/controller/PostController.java
@@ -13,8 +13,10 @@ import lombok.extern.slf4j.Slf4j;
 import org.ktb.matajo.dto.location.LocationDealResponseDto;
 import org.ktb.matajo.dto.location.LocationPostResponseDto;
 import org.ktb.matajo.dto.post.*;
+import org.ktb.matajo.entity.Storage;
 import org.ktb.matajo.global.common.CommonResponse;
 import org.ktb.matajo.global.common.ErrorResponse;
+import org.ktb.matajo.repository.StorageRepository;
 import org.ktb.matajo.security.SecurityUtil;
 import org.ktb.matajo.service.post.PostService;
 import org.springframework.http.HttpStatus;
@@ -277,6 +279,20 @@ public class PostController {
         log.info("내 게시글 조회 요청: userId={}, offset={}, limit={}", userId, offset, limit);
         List<PostResponseDto> myPosts = postService.getMyPosts(userId, offset, limit);
         return ResponseEntity.ok(CommonResponse.success("get_my_posts_success", myPosts));
+    }
+
+
+    private final StorageRepository storageRepository;
+
+    @Operation(summary = "위치 기반 보관소 조회", description = "특정 동네의 보관소 목록을 조회합니다.")
+    @GetMapping("/location/storages")
+    public ResponseEntity<CommonResponse<List<Storage>>> getStoragesByLocation(
+            @RequestParam("locationInfoId") Long locationInfoId) {
+
+        log.info("위치 기반 보관소 조회 요청: locationInfoId={}", locationInfoId);
+
+        List<Storage> storages = storageRepository.findByLocationInfoId(locationInfoId);
+        return ResponseEntity.ok(CommonResponse.success("get_storages_success", storages));
     }
 
 }

--- a/src/main/java/org/ktb/matajo/controller/PostController.java
+++ b/src/main/java/org/ktb/matajo/controller/PostController.java
@@ -14,12 +14,11 @@ import org.ktb.matajo.dto.location.LocationDealResponseDto;
 import org.ktb.matajo.dto.location.LocationPostResponseDto;
 import org.ktb.matajo.dto.post.*;
 import org.ktb.matajo.dto.storage.StorageResponseDto;
-import org.ktb.matajo.entity.Storage;
 import org.ktb.matajo.global.common.CommonResponse;
 import org.ktb.matajo.global.common.ErrorResponse;
-import org.ktb.matajo.repository.StorageRepository;
 import org.ktb.matajo.security.SecurityUtil;
 import org.ktb.matajo.service.post.PostService;
+import org.ktb.matajo.service.storage.StorageService;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
@@ -27,7 +26,6 @@ import org.springframework.web.bind.annotation.*;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
-import java.util.stream.Collectors;
 
 @Tag(name = "게시글 API", description = "게시글 CRUD 및 관련 기능을 제공하는 API")
 @Slf4j
@@ -37,6 +35,7 @@ import java.util.stream.Collectors;
 public class PostController {
 
     private final PostService postService;
+    private final StorageService storageService;
 
     @Operation(
         summary = "게시글 목록 조회",
@@ -283,27 +282,21 @@ public class PostController {
         return ResponseEntity.ok(CommonResponse.success("get_my_posts_success", myPosts));
     }
 
+    
 
-    private final StorageRepository storageRepository;
 
+    // ✅ 변경된 엔드포인트: /api/posts/storages/location
     @Operation(summary = "위치 기반 보관소 조회", description = "특정 동네의 보관소 목록을 조회합니다.")
-    @GetMapping("/location/storages")
+    @GetMapping("/storages/location")
     public ResponseEntity<CommonResponse<List<StorageResponseDto>>> getStoragesByLocation(
             @RequestParam("locationInfoId") Long locationInfoId) {
 
         log.info("위치 기반 보관소 조회 요청: locationInfoId={}", locationInfoId);
 
-        List<StorageResponseDto> dtoList = storageRepository.findByLocationInfoId(locationInfoId)
-                .stream()
-                .map(storage -> new StorageResponseDto(
-                        storage.getId(),
-                        storage.getKakaoMapLink(),
-                        storage.getName(),
-                        storage.getLocationInfoId()
-                ))
-                .collect(Collectors.toList());
+        List<StorageResponseDto> dtoList = storageService.getStoragesByLocation(locationInfoId);
 
-        return ResponseEntity.ok(CommonResponse.success("get_storages_success", dtoList));
+        return ResponseEntity.ok(CommonResponse.success("get_storages_by_location_success", dtoList));
     }
+
 
 }

--- a/src/main/java/org/ktb/matajo/dto/storage/StorageResponseDto.java
+++ b/src/main/java/org/ktb/matajo/dto/storage/StorageResponseDto.java
@@ -1,0 +1,20 @@
+package org.ktb.matajo.dto.storage;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class StorageResponseDto {
+
+    private Long id;
+
+    @JsonProperty("kakao_map_link")
+    private String kakaoMapLink;
+
+    private String name;
+
+    @JsonProperty("location_info_id")
+    private Long locationInfoId;
+}

--- a/src/main/java/org/ktb/matajo/entity/Storage.java
+++ b/src/main/java/org/ktb/matajo/entity/Storage.java
@@ -1,11 +1,6 @@
 package org.ktb.matajo.entity;
 
-import jakarta.persistence.Column;
-import jakarta.persistence.Entity;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.GenerationType;
-import jakarta.persistence.Id;
-import jakarta.persistence.Table;
+import jakarta.persistence.*;
 import lombok.Getter;
 
 @Entity
@@ -17,10 +12,43 @@ public class Storage {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @Column(name = "kakao_map_link")
+    @Column(length = 255)
+    private String name;
+
+    @Column(columnDefinition = "text")
+    private String address;
+
+    private Double x;
+    private Double y;
+
+    @Column(length = 255)
+    private String category;
+
+    @Column(length = 255)
+    private String keyword;
+
+    @Column(length = 100)
+    private String region;
+
+    @Column(length = 50)
+    private String phone;
+
+    @Column(name = "place_id")
+    private Long placeId;
+
+    @Column(name = "kakao_map_link", columnDefinition = "text")
     private String kakaoMapLink;
 
-    private String name;
+    private Integer zonecode; // int 타입
+
+    @Column(length = 100)
+    private String bname2;
+
+    @Column(length = 100)
+    private String sigungu;
+
+    @Column(length = 100)
+    private String sido;
 
     @Column(name = "location_info_id")
     private Long locationInfoId;

--- a/src/main/java/org/ktb/matajo/entity/Storage.java
+++ b/src/main/java/org/ktb/matajo/entity/Storage.java
@@ -1,0 +1,27 @@
+package org.ktb.matajo.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.Getter;
+
+@Entity
+@Table(name = "storage")
+@Getter
+public class Storage {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "kakao_map_link")
+    private String kakaoMapLink;
+
+    private String name;
+
+    @Column(name = "location_info_id")
+    private Long locationInfoId;
+}

--- a/src/main/java/org/ktb/matajo/global/error/code/ErrorCode.java
+++ b/src/main/java/org/ktb/matajo/global/error/code/ErrorCode.java
@@ -6,7 +6,6 @@ import org.springframework.http.HttpStatus;
 @Getter
 public enum ErrorCode {
     // 400 BAD REQUEST
-    // 구체적인 비즈니스 규칙 위반
     INVALID_OFFSET_OR_LIMIT(HttpStatus.BAD_REQUEST, "invalid_offset_or_limit", "페이지네이션 파라미터가 유효하지 않습니다"),
     INVALID_POST_ID(HttpStatus.BAD_REQUEST, "invalid_post_id", "게시글 ID가 유효하지 않습니다"),
     INVALID_POST_TITLE(HttpStatus.BAD_REQUEST, "invalid_post_title", "게시글 제목이 유효하지 않습니다"),
@@ -32,8 +31,6 @@ public enum ErrorCode {
     REQUIRED_AGREEMENT_MISSING(HttpStatus.BAD_REQUEST, "required_agreement_missing", "필수 약관에 동의하지 않았습니다"),
     NOTIFICATION_MESSAGE_INVALID(HttpStatus.BAD_REQUEST, "notification_message_invalid", "알림 메시지가 유효하지 않습니다"),
     NICKNAME_ALREADY_EXISTS(HttpStatus.BAD_REQUEST, "nickname_already_exists", "이미 사용 중인 닉네임입니다"),
-
-    // 일반적인 입력값 검증 오류
     INVALID_INPUT_VALUE(HttpStatus.BAD_REQUEST, "invalid_input_value", "입력값이 유효하지 않습니다"),
 
     // 401 UNAUTHORIZED
@@ -57,13 +54,13 @@ public enum ErrorCode {
     REFRESH_TOKEN_NOT_FOUND(HttpStatus.NOT_FOUND, "refresh_token_not_found", "리프레시 토큰이 존재하지 않습니다"),
     NOTIFICATION_RECEIVER_NOT_FOUND(HttpStatus.NOT_FOUND, "notification_receiver_not_found", "알림 수신자를 찾을 수 없습니다"),
 
-    // 405 METHOD NOT ALLOWED - 누락된 에러 코드 추가
+    // 405 METHOD NOT ALLOWED
     METHOD_NOT_ALLOWED(HttpStatus.METHOD_NOT_ALLOWED, "method_not_allowed", "지원하지 않는 HTTP 메소드입니다"),
 
     // 409 CONFLICT
     CHAT_USER_ALREADY_LEFT(HttpStatus.CONFLICT, "chat_user_already_left", "이미 채팅방을 나간 사용자입니다"),
 
-    //429 TOO_MANY_REQUESTS
+    // 429 TOO MANY REQUESTS
     TOO_MANY_REQUESTS(HttpStatus.TOO_MANY_REQUESTS,"too_many_requests", "요청 한도를 초과했습니다. 잠시 후 다시 시도해주세요."),
 
     // 500 INTERNAL SERVER ERROR
@@ -75,7 +72,7 @@ public enum ErrorCode {
     FAILED_TO_UPDATE_POST(HttpStatus.INTERNAL_SERVER_ERROR, "failed_to_update_post", "게시글 수정에 실패했습니다"),
     FAILED_TO_SEND_NOTIFICATION(HttpStatus.INTERNAL_SERVER_ERROR, "failed_to_send_notification", "알림 전송에 실패했습니다"),
 
-    // 502 BAD GATEWAY - 외부 API 통신 실패
+    // 502 BAD GATEWAY
     KAKAO_AUTH_FAILED(HttpStatus.BAD_GATEWAY, "kakao_auth_failed", "카카오 인증에 실패했습니다"),
     KAKAO_USERINFO_FETCH_FAILED(HttpStatus.BAD_GATEWAY, "kakao_userinfo_failed", "카카오 사용자 정보 조회에 실패했습니다");
 
@@ -88,5 +85,4 @@ public enum ErrorCode {
         this.errorMessage = errorMessage;
         this.description = description;
     }
-
 }

--- a/src/main/java/org/ktb/matajo/repository/StorageRepository.java
+++ b/src/main/java/org/ktb/matajo/repository/StorageRepository.java
@@ -1,0 +1,9 @@
+package org.ktb.matajo.repository;
+
+import org.ktb.matajo.entity.Storage;
+import org.springframework.data.jpa.repository.JpaRepository;
+import java.util.List;
+
+public interface StorageRepository extends JpaRepository<Storage, Long> {
+    List<Storage> findByLocationInfoId(Long locationInfoId);
+}

--- a/src/main/java/org/ktb/matajo/repository/StorageRepository.java
+++ b/src/main/java/org/ktb/matajo/repository/StorageRepository.java
@@ -2,6 +2,7 @@ package org.ktb.matajo.repository;
 
 import org.ktb.matajo.entity.Storage;
 import org.springframework.data.jpa.repository.JpaRepository;
+
 import java.util.List;
 
 public interface StorageRepository extends JpaRepository<Storage, Long> {

--- a/src/main/java/org/ktb/matajo/service/storage/StorageService.java
+++ b/src/main/java/org/ktb/matajo/service/storage/StorageService.java
@@ -1,0 +1,9 @@
+package org.ktb.matajo.service.storage;
+
+import org.ktb.matajo.dto.storage.StorageResponseDto;
+
+import java.util.List;
+
+public interface StorageService {
+    List<StorageResponseDto> getStoragesByLocation(Long locationInfoId);
+}

--- a/src/main/java/org/ktb/matajo/service/storage/StorageServiceImpl.java
+++ b/src/main/java/org/ktb/matajo/service/storage/StorageServiceImpl.java
@@ -1,0 +1,42 @@
+package org.ktb.matajo.service.storage;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.ktb.matajo.dto.storage.StorageResponseDto;
+import org.ktb.matajo.entity.Storage;
+import org.ktb.matajo.global.error.code.ErrorCode;
+import org.ktb.matajo.global.error.exception.BusinessException;
+import org.ktb.matajo.repository.StorageRepository;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class StorageServiceImpl implements StorageService {
+
+    private final StorageRepository storageRepository;
+
+    @Override
+    public List<StorageResponseDto> getStoragesByLocation(Long locationInfoId) {
+        if (locationInfoId == null) {
+            throw new BusinessException(ErrorCode.INVALID_LOCATION_ID);
+        }
+
+        List<Storage> storages = storageRepository.findByLocationInfoId(locationInfoId);
+
+        return storages.stream()
+                .map(s -> new StorageResponseDto(
+                        s.getId(),
+                        s.getKakaoMapLink(),
+                        s.getName(),
+                        s.getLocationInfoId()
+                ))
+                .collect(Collectors.toList());
+    }
+
+}


### PR DESCRIPTION
### Description

<!--
locationInfoId를 기준으로 특정 지역의 보관소(Storage) 목록을 조회하는 API를 추가했습니다.
프론트엔드에서 동네 선택 후, 해당 동네에 속한 보관소 리스트를 받아오기 위한 목적입니다.
-->

### Related Issues

<!--
  관련된 이슈 번호를 참고하세요.
  예: Fixes #123, Closes #456
-->
- Resolves #[이슈 번호]

### Changes Made

<!--
  이 PR에서 변경된 사항을 설명하세요.
  코드, 문서, 설정 등 변경된 내용을 상세히 기술합니다.
-->

1. Storage 엔티티 클래스 생성

2. StorageRepository 인터페이스 추가 및 findByLocationInfoId 메서드 정의

3. PostController에 /posts/location/storages API 추가 (GET, locationInfoId 파라미터 사용)

### Screenshots or Video

<!--
  변경된 사항이 UI에 영향을 미치는 경우, 변경 전후의 스크린샷이나 동영상을 첨부하세요.
-->

### Testing

<!--
  변경 사항을 테스트한 방법을 설명하세요.
  테스트한 환경 (OS, 브라우저, 장치 등)과 테스트 절차를 구체적으로 기술합니다.
-->

1. Postman에서 GET /posts/location/storages?locationInfoId=223 요청 → 응답으로 Storage 목록 반환 확인

DB에 존재하지 않는 ID로 요청 → 빈 리스트 반환 확인

응답 구조가 CommonResponse.success(...) 형태로 감싸져 있는지 확인

### Checklist

<!--
  PR 작성 시 다음 항목들을 확인하세요.
-->

- [ ] 코드가 정상적으로 컴파일되는지 확인했습니다.
- [ ] 모든 테스트가 성공적으로 통과했습니다.
- [ ] 관련 문서를 업데이트했습니다.
- [ ] PR이 관련 이슈를 정확히 참조하고 있습니다.
- [ ] 코드 스타일 가이드라인을 준수했습니다.
- [ ] 코드 리뷰어를 지정했습니다.

### Additional Notes

<!--
  리뷰어가 이해하는 데 도움이 될 추가적인 참고 사항이나 정보가 있다면 여기에 작성하세요.
-->

